### PR TITLE
Add crate publish workflow on published GitHub releases

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,22 @@
+name: Rust
+
+on:
+  release:
+    types: [published] # Only publish to crates.io when we formally publish a release
+  # For more on how to formally release shellflip, check out https://help.github.com/en/articles/creating-releases
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Login to crates.io
+      run: cargo login $CRATES_IO_TOKEN
+      env:
+        CRATES_IO_TOKEN: ${{ secrets.crates_io_token }} # https://help.github.com/en/articles/virtual-environments-for-github-actions#creating-and-using-secrets-encrypted-variables
+    - name: Dry run publish
+      run: cargo publish --dry-run
+    - name: Publish
+      run: cargo publish


### PR DESCRIPTION
Uses the same release method as cloudflare-rs i.e. releases created through GitHub manually with version bump tagged commit.