### PR TITLE
Add LifecycleHandler::pre_new_process

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -412,6 +412,8 @@ async fn spawn_child(
     user_envs: &[(OsString, OsString)],
     lifecycle_handler: &mut dyn LifecycleHandler,
 ) -> io::Result<process::Child> {
+    lifecycle_handler.pre_new_process().await;
+
     let mut args = env::args();
     let process_name = args.next().unwrap();
 

--- a/src/lifecycle.rs
+++ b/src/lifecycle.rs
@@ -19,6 +19,9 @@ pub trait LifecycleHandler: Send {
         Ok(())
     }
 
+    /// Called before the child process has been spawned.
+    async fn pre_new_process(&mut self) {}
+
     /// Called after `send_to_new_process` if the child process fails to start successfully.
     /// This gives you an opportunity to undo any state changes made in `send_to_new_process`.
     async fn new_process_failed(&mut self) {}


### PR DESCRIPTION
My ultimate goal is to persist some state on reloads and graceful shutdown to allow the next generation to use that data. I want to be able to restore this state on reboots and crashes. The actual state is the list of cache keys to prewarm, so it's ok to have it a bit stale. It is not ok to have it empty.

When storing state in a file:

* Reading the state happens on startup, no support necessary.
* Writing needs to happen before the next generation of the process starts:
  * For graceful upgrades this `pre_new_process()` hook should do the trick.
  * For graceful shutdowns there would be some other thing outside of `shellflip`.
  * For crashes we live with stale data.

Passing the data in `send_to_new_process` doesn't feel right for this, but I might be persuadable. The reason I don't like it is because there would be a split in behavior on startup:

* If there's data from the parent, save it to persistent storage (some file).
* If it's a cold start without a parent, restore the data from persistent storage.