### PR TITLE
Set restart coordinator socket to nonblocking mode

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -344,6 +344,7 @@ fn new_restart_coordination_socket_stream(
 ) -> io::Result<(Option<OwnedFd>, impl Stream<Item = RestartResponder>)> {
     if let Some(path) = restart_coordination_socket {
         let listener = bind_restart_coordination_socket(path)?;
+        listener.set_nonblocking(true)?;
         let inherit_socket = OwnedFd::from(listener.try_clone()?);
         let listener = UnixListener::from_std(listener)?;
         let st = listen_for_restart_events(listener);


### PR DESCRIPTION
This usually manifests as the process not responding to restart signal after accepting a connection on the restart socket. In practice you are probably using one or the other, so it should be rarely noticed.